### PR TITLE
[UPDATE] add   definition of   `static var category: String { get } `…

### DIFF
--- a/Sources/DDDCore/Entity/Projectable.swift
+++ b/Sources/DDDCore/Entity/Projectable.swift
@@ -2,6 +2,8 @@ public protocol Projectable {
 
     associatedtype ID: Hashable
     
+    static var category: String { get }
+    
     var id: ID { get }
     init?(events: [any DomainEvent]) throws
     func when(happened event: some DomainEvent) throws


### PR DESCRIPTION
在 protocol 補上 category 的定義