### PR TITLE
[UPDATE] change EventStoreDB source url from grady to Mendesky

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/gradyzhuo/EventStoreDB-Swift.git", from: "0.2.0"),
+        .package(url: "https://github.com/Mendesky/EventStoreDB-Swift.git", from: "0.2.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.4")
     ],
     targets: [


### PR DESCRIPTION
更改EventStoreDB的套件 改成 Mendesky 組織內的Fork版本 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 更新了EventStoreDB包的依赖URL，以确保更稳定的包管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->