### PR TITLE
Add custom metadata

### DIFF
--- a/Sources/ESDBSupport/Adapter/CustomMetadata.swift
+++ b/Sources/ESDBSupport/Adapter/CustomMetadata.swift
@@ -1,0 +1,7 @@
+public struct CustomMetadata: Codable {
+    public let className: String
+
+    public init(className: String) {
+        self.className = className
+    }
+}

--- a/Sources/ESDBSupport/Adapter/ESDBStorageCoordinator.swift
+++ b/Sources/ESDBSupport/Adapter/ESDBStorageCoordinator.swift
@@ -16,7 +16,9 @@ public class ESDBStorageCoordinator<ProjectableType: Projectable>: EventStorageC
     public func append(events: [any DDDCore.DomainEvent], byId id: ProjectableType.ID, version: UInt?) async throws -> UInt? {
         let streamName = ProjectableType.getStreamName(id: id)
         let events = try events.map {
-            try EventData(id: $0.id, eventType: $0.eventType, payload: $0)
+            let encoder = JSONEncoder()
+            let customMetadata = try encoder.encode(CustomMetadata(className: "\(type(of: $0))"))
+            return try EventData(id: $0.id, eventType: $0.eventType, payload: $0, customMetadata: customMetadata)
         }
 
         let response = try await client.appendStream(to: .init(name: streamName), events: events) { options in

--- a/Sources/ESDBSupport/Adapter/RecordedEvent.swift
+++ b/Sources/ESDBSupport/Adapter/RecordedEvent.swift
@@ -2,7 +2,7 @@ import EventStoreDB
 import Foundation
 
 extension RecordedEvent {
-    public var mappingName: String {
+    public var mappingClassName: String {
         let decoder = JSONDecoder()
         do {
             let customMetadata = try decoder.decode(CustomMetadata.self, from: self.customMetadata)

--- a/Sources/ESDBSupport/Adapter/RecordedEvent.swift
+++ b/Sources/ESDBSupport/Adapter/RecordedEvent.swift
@@ -1,0 +1,14 @@
+import EventStoreDB
+import Foundation
+
+extension RecordedEvent {
+    public var mappingName: String {
+        let decoder = JSONDecoder()
+        do {
+            let customMetadata = try decoder.decode(CustomMetadata.self, from: self.customMetadata)
+            return customMetadata.className
+        } catch {
+            return self.eventType
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了 `CustomMetadata` 结构体，用于在事件数据中添加自定义元数据
	- 为 `RecordedEvent` 添加了 `mappingName` 计算属性，提供事件类名的解析

- **改进**
	- 增强了事件存储协调器中事件追加的元数据处理能力
	- 优化了事件元数据的编码和解码机制

<!-- end of auto-generated comment: release notes by coderabbit.ai -->