### PR TITLE
產 readmodel 的 EventMapper 時，要補上created 和 deleted 的事件。

### DIFF
--- a/Sources/DomainEventGenerator/Generator/ProjectionModel/EventProjectionDefinition.swift
+++ b/Sources/DomainEventGenerator/Generator/ProjectionModel/EventProjectionDefinition.swift
@@ -21,15 +21,23 @@ package struct EventProjectionDefinition: Codable {
         self.createdEvent = createdEvent
         self.deletedEvent = deletedEvent
         self.events = events
+        if case .readModel = model {
+            self.events.append(createdEvent)
+            if let deletedEvent {
+                self.events.append(deletedEvent)
+            }
+        }
     }
     
     package init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.idType = try container.decodeIfPresent(PropertyDefinition.PropertyType.self, forKey: .idType) ?? .string
-        self.model = try container.decode(EventProjectionDefinition.ModelKind.self, forKey: .model)
-        self.createdEvent = try container.decode(String.self, forKey: .createdEvent)
-        self.deletedEvent = try container.decodeIfPresent(String.self, forKey: .deletedEvent)
-        self.events = try container.decodeIfPresent([String].self, forKey: .events) ?? []
+        let idType = try container.decodeIfPresent(PropertyDefinition.PropertyType.self, forKey: .idType) ?? .string
+        let model = try container.decode(EventProjectionDefinition.ModelKind.self, forKey: .model)
+        let createdEvent = try container.decode(String.self, forKey: .createdEvent)
+        let deletedEvent = try container.decodeIfPresent(String.self, forKey: .deletedEvent)
+        let events = try container.decodeIfPresent([String].self, forKey: .events) ?? []
+        
+        self.init(idType: idType, model: model, createdEvent: createdEvent, deletedEvent: deletedEvent, events: events)
     }
 }
 


### PR DESCRIPTION
…to events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 优化了对象初始化流程，实现了基于模型类型的事件处理，以确保关键事件能在适当场景下正确覆盖。
  - 改善了解码逻辑，通过先预处理数据再进行初始化，提升了整体流程的清晰度和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->