### PR TITLE
Dev/fix bug

### DIFF
--- a/Plugins/DomainEventGeneratorPlugin/Plugin.swift
+++ b/Plugins/DomainEventGeneratorPlugin/Plugin.swift
@@ -29,7 +29,7 @@ enum PluginError: Error {
         }
         
         //generated directories target
-        let generatedTargetDirectory = pluginWorkDirectory.appending(component: "generated-projection-models", directoryHint: .isDirectory)
+        let generatedTargetDirectory = pluginWorkDirectory.appending(component: "generated", directoryHint: .isDirectory)
 
         //generated files target
         let generatedEventsSource = generatedTargetDirectory.appending(path: "generated-event.swift")

--- a/Plugins/DomainEventGeneratorPlugin/Plugin.swift
+++ b/Plugins/DomainEventGeneratorPlugin/Plugin.swift
@@ -28,20 +28,24 @@ enum PluginError: Error {
             throw PluginError.configFileNotFound
         }
         
-        let generatedEventsSource = pluginWorkDirectory.appending(path: "generated-event.swift")
-        
+        //generated directories target
+        let generatedTargetDirectory = pluginWorkDirectory.appending(component: "generated-projection-models", directoryHint: .isDirectory)
+
+        //generated files target
+        let generatedEventsSource = generatedTargetDirectory.appending(path: "generated-event.swift")
     
         return [
-            try .buildCommand(displayName: "Event Generating...\(inputSource.url.path())", executable: tool("generate"), arguments: [
-                "event",
-                "--configuration", "\(configSource.url.path())",
-                "--output", "\(generatedEventsSource.path())",
-                "\(inputSource.url.path())"
-            ], inputFiles: [
-                inputSource.url
-            ], outputFiles: [
-                generatedEventsSource
-            ])
+            try .prebuildCommand(
+                displayName: "Event Generating...\(inputSource.url.path())",
+                executable: tool("generate"),
+                arguments: [
+                    "event",
+                    "--configuration", "\(configSource.url.path())",
+                    "--output", "\(generatedEventsSource.path())",
+                    "\(inputSource.url.path())"
+                ],
+                outputFilesDirectory: generatedTargetDirectory)
+            
         ]
     }
 }

--- a/Plugins/ProjectionModelGeneratorPlugin/Plugin.swift
+++ b/Plugins/ProjectionModelGeneratorPlugin/Plugin.swift
@@ -34,7 +34,7 @@ enum PluginError: Error {
         }
         
         //generated directories target
-        let generatedTargetDirectory = pluginWorkDirectory.appending(component: "generated-projection-models", directoryHint: .isDirectory)
+        let generatedTargetDirectory = pluginWorkDirectory.appending(component: "generated", directoryHint: .isDirectory)
 
         //generated files target
         let generatedProjectionHelperSource = generatedTargetDirectory.appending(path: "generated-projection-model.swift")

--- a/Plugins/ProjectionModelGeneratorPlugin/Plugin.swift
+++ b/Plugins/ProjectionModelGeneratorPlugin/Plugin.swift
@@ -33,36 +33,38 @@ enum PluginError: Error {
             throw PluginError.configFileNotFound
         }
         
-        let generatedProjectionHelperSource = pluginWorkDirectory.appending(path: "generated-projection-model.swift")
-        let generatedEventMapperSource = pluginWorkDirectory.appending(path: "generated-event-mapper.swift")
+        //generated directories target
+        let generatedTargetDirectory = pluginWorkDirectory.appending(component: "generated-projection-models", directoryHint: .isDirectory)
+
+        //generated files target
+        let generatedProjectionHelperSource = generatedTargetDirectory.appending(path: "generated-projection-model.swift")
+        let generatedEventMapperSource = generatedTargetDirectory.appending(path: "generated-event-mapper.swift")
         
         return [
-            try .buildCommand(displayName: "ProjectionModel Generating...\(projectionModelSource.url.path())", executable: tool("generate"), arguments: [
-                "projection-model",
-                "--configuration", configSource.url.path(),
-                "--default-aggregate-root-name", targetName,
-                "--output", generatedProjectionHelperSource.path(),
-                "--events", eventSource.url.path(),
-                "\(projectionModelSource.url.path())"
-            ], inputFiles: [
-                eventSource.url,
-                projectionModelSource.url
-            ], outputFiles: [
-                generatedProjectionHelperSource
-            ]),
-            try .buildCommand(displayName: "EventMapper Generating...\(eventSource.url.path())", executable: tool("generate"), arguments: [
-                "event-mapper",
-                "--configuration", configSource.url.path(),
-                "--default-aggregate-root-name", targetName,
-                "--output", generatedEventMapperSource.path(),
-                eventSource.url.path(),
-                projectionModelSource.url.path()
-            ], inputFiles: [
-                eventSource.url,
-                projectionModelSource.url
-            ], outputFiles: [
-                generatedEventMapperSource
-            ])
+            try .prebuildCommand(
+                displayName: "ProjectionModel Generating...\(projectionModelSource.url.path())",
+                executable: tool("generate"),
+                arguments: [
+                    "projection-model",
+                    "--configuration", configSource.url.path(),
+                    "--default-aggregate-root-name", targetName,
+                    "--output", generatedProjectionHelperSource.path(),
+                    "--events", eventSource.url.path(),
+                    "\(projectionModelSource.url.path())"
+                ],
+                outputFilesDirectory: generatedTargetDirectory),
+            try .prebuildCommand(
+                displayName: "EventMapper Generating...\(eventSource.url.path())",
+                executable: tool("generate"),
+                arguments: [
+                    "event-mapper",
+                    "--configuration", configSource.url.path(),
+                    "--default-aggregate-root-name", targetName,
+                    "--output", generatedEventMapperSource.path(),
+                    eventSource.url.path(),
+                    projectionModelSource.url.path()
+                ],
+                outputFilesDirectory: generatedTargetDirectory)
         ]
     }
 }

--- a/Sources/DomainEventGenerator/DomainEventGeneratorError.swift
+++ b/Sources/DomainEventGenerator/DomainEventGeneratorError.swift
@@ -1,0 +1,11 @@
+//
+//  DomainEventGeneratorError.swift
+//  DDDKit
+//
+//  Created by Grady Zhuo on 2025/4/21.
+//
+import Foundation
+
+public enum DomainEventGeneratorError: Error {
+    case invalidYamlFile(url: URL, reason: String)
+}

--- a/Sources/DomainEventGenerator/Generator/EventMapper/EventMapperGenerator.swift
+++ b/Sources/DomainEventGenerator/Generator/EventMapper/EventMapperGenerator.swift
@@ -34,7 +34,7 @@ package struct EventMapperGenerator {
         
         for eventName in eventNames {
             lines.append("""
-        case "\\(\(eventName).self)":
+        case "\(eventName)":
             try eventData.decode(to: \(eventName).self)
 """)
         }

--- a/Sources/DomainEventGenerator/Generator/ProjectionModel/ProjectionModelGenerator.swift
+++ b/Sources/DomainEventGenerator/Generator/ProjectionModel/ProjectionModelGenerator.swift
@@ -31,6 +31,9 @@ package struct ProjectionModelGenerator {
     
     package init(projectionModelYamlFileURL: URL, aggregateRootName: String, aggregateEventsYamlFileURL: URL) throws {
         let yamlData = try Data(contentsOf: projectionModelYamlFileURL)
+        if yamlData.isEmpty {
+            throw DomainEventGeneratorError.invalidYamlFile(url: projectionModelYamlFileURL, reason: "The yaml file is empty.")
+        }
         let yamlDecoder = YAMLDecoder()
         let definitions = try yamlDecoder.decode([String: EventProjectionDefinition].self, from: yamlData)
         

--- a/Sources/generate/EventMapper.swift
+++ b/Sources/generate/EventMapper.swift
@@ -62,7 +62,11 @@ struct GenerateEventMapperCommand: ParsableCommand {
         lines.append("")
         
         for (modelName, projectionModelDefinition) in projectionModelGenerator.definitions {
-            
+            var eventNames = projectionModelDefinition.events
+            eventNames.append(projectionModelDefinition.createdEvent)
+            if let deletedEvent = projectionModelDefinition.deletedEvent {
+                eventNames.append(deletedEvent)
+            }
             let eventMapperGenerator = EventMapperGenerator(modelName: modelName, eventNames: projectionModelDefinition.events)
             lines.append(contentsOf: eventMapperGenerator.render(accessLevel: accessModifier))
             lines.append("")

--- a/Sources/generate/EventMapper.swift
+++ b/Sources/generate/EventMapper.swift
@@ -67,7 +67,7 @@ struct GenerateEventMapperCommand: ParsableCommand {
             if let deletedEvent = projectionModelDefinition.deletedEvent {
                 eventNames.append(deletedEvent)
             }
-            let eventMapperGenerator = EventMapperGenerator(modelName: modelName, eventNames: projectionModelDefinition.events)
+            let eventMapperGenerator = EventMapperGenerator(modelName: modelName, eventNames: eventNames)
             lines.append(contentsOf: eventMapperGenerator.render(accessLevel: accessModifier))
             lines.append("")
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增了公开枚举类型 `DomainEventGeneratorError`，用于更详细地描述 YAML 文件无效时的错误信息。

- **修复**
  - 现在在读取 YAML 文件时会检测文件是否为空，若为空则会抛出相应错误，避免后续处理异常。

- **重构**
  - 插件生成的文件统一输出到新的 `generated` 子目录下，便于管理和查找。
  - 插件的生成命令由指定单个输出文件改为指定输出目录，提升了生成文件的灵活性。
  - 优化了事件名称的处理逻辑，包含了创建和删除事件，使事件名称列表更全面。
  - 调整了事件映射的匹配方式，改为使用事件名称的字符串字面量，提高匹配准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->