### PR TITLE
[UPDATE] modify handle recorded event from JBEventBus to DomainEventBus

### DIFF
--- a/Sources/DDDCore/UseCase/EventBus/DomainEventBus.swift
+++ b/Sources/DDDCore/UseCase/EventBus/DomainEventBus.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 public protocol DomainEventBus: Sendable {
-    var eventSubscribers: [any EventSubscriber] { get }
+    associatedtype Subscriber
+    var eventSubscribers: [Subscriber] { get }
     
     func publish<EventType: DomainEvent>(event: EventType) async throws
     func subscribe<EventType: DomainEvent>(to eventType: EventType.Type, handler: @escaping (_ event: EventType) async throws -> Void) rethrows

--- a/Sources/DDDCore/UseCase/EventBus/DomainEventBus.swift
+++ b/Sources/DDDCore/UseCase/EventBus/DomainEventBus.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public protocol DomainEventBus: Sendable {
+    var eventSubscribers: [any EventSubscriber] { get }
+    
     func publish<EventType: DomainEvent>(event: EventType) async throws
     func subscribe<EventType: DomainEvent>(to eventType: EventType.Type, handler: @escaping (_ event: EventType) async throws -> Void) rethrows
 }

--- a/Sources/DDDCore/UseCase/EventBus/EventSubscriber.swift
+++ b/Sources/DDDCore/UseCase/EventBus/EventSubscriber.swift
@@ -1,0 +1,12 @@
+//
+//  EventSubscriber.swift
+//  DDDKit
+//
+//  Created by Grady Zhuo on 2025/5/8.
+//
+
+public protocol EventSubscriber: Sendable{
+    associatedtype Event: DomainEvent
+    var eventName: String { get }
+    var handle: @Sendable (Event) async throws -> Void { get }
+}

--- a/Sources/ESDBSupport/Adapter/DomainEventBus+KurrentDB.swift
+++ b/Sources/ESDBSupport/Adapter/DomainEventBus+KurrentDB.swift
@@ -7,9 +7,9 @@
 import DDDCore
 import KurrentDB
 
-extension DomainEventBus{
+extension DomainEventBus where Subscriber: EventSubscriber{
     
-    private func publish<Subscriber: EventSubscriber>(of subscriber: Subscriber, event: RecordedEvent) async throws{
+    private func publish(of subscriber: Subscriber, event: RecordedEvent) async throws{
         do{
             guard let event = try event.decode(to: Subscriber.Event.self) else {
                 return

--- a/Sources/ESDBSupport/Adapter/DomainEventBus+KurrentDB.swift
+++ b/Sources/ESDBSupport/Adapter/DomainEventBus+KurrentDB.swift
@@ -5,10 +5,9 @@
 //  Created by Grady Zhuo on 2025/4/23.
 //
 import DDDCore
-import JBEventBus
 import KurrentDB
 
-extension JBEventBus{
+extension DomainEventBus{
     
     private func publish<Subscriber: EventSubscriber>(of subscriber: Subscriber, event: RecordedEvent) async throws{
         do{

--- a/Sources/JBEventBus/JBEventBus.swift
+++ b/Sources/JBEventBus/JBEventBus.swift
@@ -1,19 +1,12 @@
 import DDDCore
 
-package protocol EventSubscriber: Sendable{
-    associatedtype Event: DomainEvent
-    var eventName: String { get }
-    var handle: @Sendable (Event) async throws -> Void { get }
-}
-
-
 package struct GeneralSubscriber<Event: DomainEvent>: EventSubscriber{
     package let eventName: String
     package let handle: @Sendable (Event) async throws -> Void
 }
 
 public actor JBEventBus: @preconcurrency DomainEventBus {
-    package private(set) var eventSubscribers: [any EventSubscriber]
+    public private(set) var eventSubscribers: [any EventSubscriber]
 
     public func publish(event: some DomainEvent) async throws {
         try await withThrowingDiscardingTaskGroup { group in


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增了 `EventSubscriber` 协议，用于异步处理领域事件订阅。
  - 领域事件总线协议增加了关联类型 `Subscriber` 及只读属性 `eventSubscribers`，支持更灵活的订阅者类型。

- **可见性调整**
  - 事件总线的当前订阅者列表现在可被公开访问。
  - `JBEventBus` 的订阅者属性访问权限提升为公开。

- **重构**
  - 移除了冗余的 `EventSubscriber` 协议声明，并调整了相关扩展的适用对象。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->