### PR TITLE
[UDPATE] remove Sendable

### DIFF
--- a/Sources/DDDCore/DomainEvent.swift
+++ b/Sources/DDDCore/DomainEvent.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol DomainEvent: Codable, Identifiable, Sendable where ID == UUID {
+public protocol DomainEvent: Codable, Identifiable where ID == UUID {
     var eventType: String { get }
     var aggregateRootId: String { get }
     var occurred: Date { get }

--- a/Sources/DDDCore/Entity/AggregateRootMetadata.swift
+++ b/Sources/DDDCore/Entity/AggregateRootMetadata.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public final class AggregateRootMetadata: Sendable {
+public final class AggregateRootMetadata {
     var events: [any DomainEvent] = []
 
     public package(set) var deleted: Bool

--- a/Sources/DDDCore/UseCase/EventBus/DomainEventBus.swift
+++ b/Sources/DDDCore/UseCase/EventBus/DomainEventBus.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol DomainEventBus: Sendable {
+public protocol DomainEventBus {
     associatedtype Subscriber
     var eventSubscribers: [Subscriber] { get }
     

--- a/Sources/DDDCore/UseCase/EventBus/EventSubscriber.swift
+++ b/Sources/DDDCore/UseCase/EventBus/EventSubscriber.swift
@@ -5,8 +5,8 @@
 //  Created by Grady Zhuo on 2025/5/8.
 //
 
-public protocol EventSubscriber: Sendable{
+public protocol EventSubscriber{
     associatedtype Event: DomainEvent
     var eventName: String { get }
-    var handle: @Sendable (Event) async throws -> Void { get }
+    var handle: (Event) async throws -> Void { get }
 }

--- a/Sources/DDDCore/UseCase/EventBus/EventSubscriber.swift
+++ b/Sources/DDDCore/UseCase/EventBus/EventSubscriber.swift
@@ -8,5 +8,5 @@
 public protocol EventSubscriber{
     associatedtype Event: DomainEvent
     var eventName: String { get }
-    var handle: (Event) async throws -> Void { get }
+    var handle: @Sendable (Event) async throws -> Void { get }
 }

--- a/Sources/JBEventBus/JBEventBus.swift
+++ b/Sources/JBEventBus/JBEventBus.swift
@@ -2,7 +2,7 @@ import DDDCore
 
 package struct GeneralSubscriber<Event: DomainEvent>: EventSubscriber{
     package let eventName: String
-    package let handle: (Event) async throws -> Void
+    package let handle: @Sendable (Event) async throws -> Void
 }
 
 public class JBEventBus: DomainEventBus {

--- a/Sources/JBEventBus/JBEventBus.swift
+++ b/Sources/JBEventBus/JBEventBus.swift
@@ -2,10 +2,10 @@ import DDDCore
 
 package struct GeneralSubscriber<Event: DomainEvent>: EventSubscriber{
     package let eventName: String
-    package let handle: @Sendable (Event) async throws -> Void
+    package let handle: (Event) async throws -> Void
 }
 
-public actor JBEventBus: @preconcurrency DomainEventBus {
+public class JBEventBus: DomainEventBus {
     public private(set) var eventSubscribers: [any EventSubscriber]
 
     public func publish(event: some DomainEvent) async throws {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **重构**
  - 移除了部分协议和类的 Sendable 并发约束，包括 DomainEvent、AggregateRootMetadata、DomainEventBus 和 EventSubscriber。
  - 变更 JBEventBus 的并发模型，将其从 actor 改为 class，并移除了相关的 @preconcurrency 标记。
  - 部分异步处理闭包类型移除了 @Sendable 属性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->