### PR TITLE
[FIX] compiler dereference a null GenericSignature Error

### DIFF
--- a/Sources/TestUtility/TestBundle.swift
+++ b/Sources/TestUtility/TestBundle.swift
@@ -38,9 +38,10 @@ public actor TestBundle {
     }
     
     public func clearStreams() async {
-        await withTaskGroup { group in
+        await withTaskGroup(of: Void.self) { group in
             for streamIdentifier in self.streamIdentifiers {
-                group.addTask { [unowned self] in
+                group.addTask { [weak self] in
+                    guard let self else { return }
                     await self.clearStream(streamIdentifier: streamIdentifier)
                 }
             }


### PR DESCRIPTION
補充：
1. 編譯器在把 AST 轉成 SIL 時，需要用到巢狀 async 閉包的泛型簽章，但拿到的是 nil，導致在生成 SIL 時解引用 (dereference) 失敗而 crash (signal 6)

2. 用 Swift 6.1 toolchain 但 -swift-version 5 時，某些最佳化路徑會不一樣